### PR TITLE
Log link to refund tx instead of order creation tx

### DIFF
--- a/script/refunder.js
+++ b/script/refunder.js
@@ -34,7 +34,7 @@ async function main() {
   const new_tx = await signer.sendTransaction(new_raw_tx);
   console.log("Mining transaction...");
   // Waiting for the transaction to be mined
-  const new_receipt = await tx.wait();
+  const new_receipt = await new_tx.wait();
   // The transaction is now on chain!
   console.log(`Mined transaction https://${network}.etherscan.io/tx/${new_receipt.transactionHash}`);
 }

--- a/script/refunder.js
+++ b/script/refunder.js
@@ -33,11 +33,10 @@ async function main() {
   const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
   const new_tx = await signer.sendTransaction(new_raw_tx);
   console.log("Mining transaction...");
-  console.log(`https://${network}.etherscan.io/tx/${tx.hash}`);
   // Waiting for the transaction to be mined
   const new_receipt = await tx.wait();
   // The transaction is now on chain!
-  console.log(`Mined in block ${receipt.blockNumber}`);
+  console.log(`Mined transaction https://${network}.etherscan.io/tx/${new_receipt.transactionHash}`);
 }
 
 main();

--- a/script/refunder.js
+++ b/script/refunder.js
@@ -36,7 +36,8 @@ async function main() {
   // Waiting for the transaction to be mined
   const new_receipt = await new_tx.wait();
   // The transaction is now on chain!
-  console.log(`Mined transaction https://${network}.etherscan.io/tx/${new_receipt.transactionHash}`);
+  const network_prefix = network === "mainnet" ? "" : `${network}.`
+  console.log(`Mined transaction https://${network_prefix}etherscan.io/tx/${new_receipt.transactionHash}`);
 }
 
 main();


### PR DESCRIPTION
While manually refunding orders I was surprised that the refunder logs the link to the order creation tx instead of the refund tx. That seems like a bug since I already have to know the order creation tx in order to run the refunder.

This PR logs the link to the refund tx and drops the log for the block number because that can be seen on etherscan.