### PR TITLE
Add more details to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ yarn
 
 ### execution
 
-In order to inspect only the transaction to be refunded, you can run:
+In order to inspect only the transaction to be refunded, you can run(error is expected in the output):
 
 ```
 export INFURA_KEY=
@@ -31,3 +31,5 @@ export PRIVATE_KEY=
 
 node script/refunder.js
 ```
+
+In case of gas estimation or any other node-related issue, use `NODE_URL` env variable to point to a different node(e.g. `rpc.mevblocker.io`).


### PR DESCRIPTION
The absence of this information might lead to confusion:

- When inspecting the tx, an error occurs, which is expected.
- `NODE_URL` env param can be used to set another node RPC URL.